### PR TITLE
#5 unique client name to prevent reconenct loop caused by ClientName collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Just add this to your pom.xml file:
         <dependency>
             <groupId>community.solace.spring.integration</groupId>
             <artifactId>solace-spring-integration-leader</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
         </dependency>
 ```
 ## Config

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>community.solace.spring.integration</groupId>
 	<artifactId>solace-spring-integration-leader</artifactId>
-	<version>1.1.2</version>
+	<version>1.1.3</version>
 
 	<name>Solace Spring Integration Leader</name>
 	<description>This project allows for Spring Integration Leader Election using Solace Exclusive Queues</description>
@@ -15,6 +15,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<build.timestamp>${maven.build.timestamp}</build.timestamp>
+		<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
 
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
@@ -228,6 +230,39 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>templating-maven-plugin</artifactId>
+				<version>1.0.0</version>
+				<executions>
+					<execution>
+						<id>generate-templated-sources</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>filter-sources</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.2.0</version>
+				<executions>
+					<execution>
+						<id>add-generated-sources</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${basedir}/target/generated-sources/java-templates</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>

--- a/src/main/java-templates/community/solace/spring/integration/leader/SolaceBinderClientInfoProvider.java
+++ b/src/main/java-templates/community/solace/spring/integration/leader/SolaceBinderClientInfoProvider.java
@@ -1,0 +1,17 @@
+package community.solace.spring.integration.leader;
+
+import com.solacesystems.jcsmp.impl.client.ClientInfoProvider;
+
+class SolaceBinderClientInfoProvider extends ClientInfoProvider {
+    public String getSoftwareVersion() {
+        return String.format("@project.version@ (%s)", super.getSoftwareVersion());
+    }
+
+    public String getSoftwareDate() {
+        return String.format("@build.timestamp@ (%s)", super.getSoftwareDate());
+    }
+
+    public String getPlatform() {
+        return this.getPlatform("solace-spring-integration-leader");
+    }
+}

--- a/src/main/java/community/solace/spring/integration/leader/SolaceLeaderAutoConfiguration.java
+++ b/src/main/java/community/solace/spring/integration/leader/SolaceLeaderAutoConfiguration.java
@@ -1,8 +1,12 @@
 package community.solace.spring.integration.leader;
 
+import java.util.UUID;
+
+import com.solacesystems.jcsmp.JCSMPProperties;
 import community.solace.spring.integration.leader.aspect.LeaderAwareAspect;
 import community.solace.spring.integration.leader.leader.SolaceLeaderConfig;
 import community.solace.spring.integration.leader.leader.SolaceLeaderInitiator;
+import community.solace.spring.integration.leader.SolaceBinderClientInfoProvider;
 import com.solacesystems.jcsmp.SpringJCSMPFactory;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -10,6 +14,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 
 @Configuration
 @EnableConfigurationProperties(SolaceLeaderConfig.class)
@@ -17,8 +22,26 @@ public class SolaceLeaderAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public SolaceLeaderInitiator solaceLeaderInitiator(SpringJCSMPFactory solaceFactory, SolaceLeaderConfig solaceLeaderConfig, ApplicationContext appContext) {
-        return new SolaceLeaderInitiator(solaceFactory, solaceLeaderConfig, appContext);
+    public SolaceLeaderInitiator solaceLeaderInitiator(JCSMPProperties jcsmpProperties, SolaceLeaderConfig solaceLeaderConfig, ApplicationContext appContext) {
+        JCSMPProperties myJcsmpProperties = (JCSMPProperties) jcsmpProperties.clone();
+
+        myJcsmpProperties.setProperty(JCSMPProperties.CLIENT_NAME, computeUniqueClientName(myJcsmpProperties));
+        myJcsmpProperties.setProperty(JCSMPProperties.CLIENT_INFO_PROVIDER, new SolaceBinderClientInfoProvider());
+
+        return new SolaceLeaderInitiator(new SpringJCSMPFactory(myJcsmpProperties), solaceLeaderConfig, appContext);
+    }
+
+    /**
+     * Creates a unique client name to create a JCSMP session.
+     * Otherwise, no connection to the broker can be established if the application also creates a JCSMP session,
+     * because a unique client name is required for each session.
+     */
+    private String computeUniqueClientName(JCSMPProperties jcsmpProperties) {
+        String clientName = (String) jcsmpProperties.getProperty(JCSMPProperties.CLIENT_NAME);
+        if (!StringUtils.hasText(clientName)) {
+            clientName = UUID.randomUUID().toString();
+        }
+        return clientName + ".solace-spring-integration-leader";
     }
 
     @Bean


### PR DESCRIPTION
Fixing name collision by suffix client name with: ".solace-spring-integration-leader"
Add ClientInfoProvider to provide detailed information about the client:
![image](https://user-images.githubusercontent.com/512850/176989320-e25f9917-2dc6-476f-a323-67fcbb4a7390.png)


