### PR TITLE
Fix conditional on missing class package name

### DIFF
--- a/src/main/java/community/solace/spring/integration/leader/SolaceLeaderAutoConfiguration.java
+++ b/src/main/java/community/solace/spring/integration/leader/SolaceLeaderAutoConfiguration.java
@@ -50,7 +50,7 @@ public class SolaceLeaderAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    @ConditionalOnMissingClass({"com.solace.spring.cloud.stream.binder.config.JCSMPSessionConfiguration"})
+    @ConditionalOnMissingClass({"com.solace.spring.cloud.stream.binder.config.autoconfigure.JCSMPSessionConfiguration"})
     @ConditionalOnProperty(name = "solace.java.host")
     public JCSMPSession solaceSessionLeaderElection(JCSMPProperties jcsmpProperties, @Nullable SolaceSessionOAuth2TokenProvider solaceSessionOAuth2TokenProvider) throws JCSMPException {
         JCSMPProperties myJcsmpProperties = (JCSMPProperties) jcsmpProperties.clone();


### PR DESCRIPTION
The package name seems to have changed, see https://github.com/SchweizerischeBundesbahnen/spring-cloud-stream-binder/blob/5.0.5/src/main/java/com/solace/spring/cloud/stream/binder/config/autoconfigure/JCSMPSessionConfiguration.java#L1